### PR TITLE
Fixed oversized itemstack not sync-ed properly

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -128,6 +128,9 @@ dependencies {
     implementation fg.deobf("mezz.jei:jei-${mc_version}-forge:${jei_version}")
     implementation fg.deobf("dev.emi:emi-forge:${emi_version}")
 
+    implementation fg.deobf("curse.maven:sophisticated-core-618298:6859221")
+    implementation fg.deobf("curse.maven:sophisticated-storage-619320:6869026")
+
     annotationProcessor "org.spongepowered:mixin:0.8.5:processor"
 
 }

--- a/src/main/java/tfar/craftingstation/CraftingStationMenu.java
+++ b/src/main/java/tfar/craftingstation/CraftingStationMenu.java
@@ -3,6 +3,8 @@ package tfar.craftingstation;
 import com.illusivesoulworks.polymorph.common.crafting.RecipeSelection;
 import net.minecraft.world.inventory.*;
 import net.minecraftforge.common.capabilities.ForgeCapabilities;
+import net.p3pp3rf1y.sophisticatedcore.common.gui.HighStackCountSynchronizer;
+import org.jetbrains.annotations.NotNull;
 import tfar.craftingstation.init.ModMenuTypes;
 import tfar.craftingstation.network.PacketHandler;
 import tfar.craftingstation.network.S2CLastRecipePacket;
@@ -633,5 +635,16 @@ public class CraftingStationMenu extends AbstractContainerMenu {
 
     public NonNullList<ItemStack> getRemainingItems() {
         return lastRecipe != null && lastRecipe.matches(craftMatrix, world) ? lastRecipe.getRemainingItems(craftMatrix) : craftMatrix.getStackList();
+    }
+
+    @Override
+    public void setSynchronizer(@NotNull ContainerSynchronizer pSynchronizer) {
+        if(ModList.get().isLoaded("sophisticatedcore")) {
+            if(pSynchronizer instanceof ServerPlayer serverPlayer) {
+                super.setSynchronizer(new HighStackCountSynchronizer(serverPlayer));
+            }
+        } else {
+            super.setSynchronizer(pSynchronizer);
+        }
     }
 }


### PR DESCRIPTION
Fixed #1.

This is just a workaround to Sophisticated things, where when `sophisticatedcore` exists, we try to use thier sync stuff.

This is much more complicated than I thought. I need more test on this, so I made it draft.